### PR TITLE
Add Diesel trait implementations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,12 @@ edition = "2018"
 description = "High-performance ISO8601 Timestamp formatting and parsing"
 keywords = ["date", "time", "iso8601", "formatting", "parsing"]
 readme = "README.md"
-categories = ["date-and-time", "no-std", "parser-implementations", "value-formatting"]
+categories = [
+    "date-and-time",
+    "no-std",
+    "parser-implementations",
+    "value-formatting",
+]
 license = "MIT OR Apache-2.0"
 include = ["src/**/*", "LICENSE-*", "README.md"]
 documentation = "https://docs.rs/iso8601-timestamp"
@@ -18,6 +23,7 @@ features = ["serde", "pg", "schema", "rusqlite", "rand", "quickcheck"]
 [features]
 std = []
 bson = []
+diesel-pg = ["diesel", "diesel/postgres_backend"]
 js = ["js-sys"]
 pg = ["postgres-types", "bytes", "std"]
 rusqlite = ["dep:rusqlite", "std"]
@@ -30,9 +36,15 @@ lookup = []                                        # Use lookup table during for
 default = ["std", "serde", "lookup"]
 
 [dependencies]
+diesel = { optional = true, version = "2", default-features = false, features = [
+    "time",
+    "with-deprecated",
+] }
 serde = { optional = true, version = "1" }
 time = { version = "0.3", default-features = false, features = ["macros"] }
-postgres-types = { optional = true, version = "0.2.2", features = ["with-time-0_3"] }
+postgres-types = { optional = true, version = "0.2.2", features = [
+    "with-time-0_3",
+] }
 bytes = { optional = true, version = "1.1.0" }
 generic-array = "0.14.4"
 schemars = { optional = true, version = "0.8.8" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,6 +105,7 @@ pub use ts_str::{FormatString, TimestampStr};
 /// UTC Timestamp with nanosecond precision, millisecond-precision when serialized to serde (JSON).
 ///
 /// A `Deref`/`DerefMut` implementation is provided to gain access to the inner `PrimitiveDateTime` object.
+#[cfg_attr(feature = "diesel", derive(::diesel::FromSqlRow))]
 #[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 #[repr(transparent)]
 pub struct Timestamp(PrimitiveDateTime);
@@ -544,6 +545,63 @@ mod serde_impl {
             }
 
             deserializer.deserialize_any(TsVisitor)
+        }
+    }
+}
+
+#[cfg(feature = "diesel")]
+mod diesel_impl {
+    #[cfg(feature = "diesel-pg")]
+    use diesel::sql_types::Timestamptz as DbTimestamptz;
+    use diesel::{
+        backend::Backend,
+        deserialize::{self, FromSql},
+        serialize::{self, ToSql},
+        sql_types::Timestamp as DbTimestamp,
+    };
+    use time::PrimitiveDateTime;
+
+    use super::Timestamp;
+
+    impl<DB> FromSql<DbTimestamp, DB> for Timestamp
+    where
+        DB: Backend,
+        PrimitiveDateTime: FromSql<DbTimestamp, DB>,
+    {
+        fn from_sql(bytes: <DB as Backend>::RawValue<'_>) -> deserialize::Result<Self> {
+            <PrimitiveDateTime as FromSql<DbTimestamp, DB>>::from_sql(bytes).map(Timestamp::from)
+        }
+    }
+
+    #[cfg(feature = "diesel-pg")]
+    impl<DB> FromSql<DbTimestamptz, DB> for Timestamp
+    where
+        DB: Backend,
+        PrimitiveDateTime: FromSql<DbTimestamptz, DB>,
+    {
+        fn from_sql(bytes: <DB as Backend>::RawValue<'_>) -> deserialize::Result<Self> {
+            <PrimitiveDateTime as FromSql<DbTimestamptz, DB>>::from_sql(bytes).map(Timestamp::from)
+        }
+    }
+
+    impl<DB> ToSql<DbTimestamp, DB> for Timestamp
+    where
+        DB: Backend,
+        PrimitiveDateTime: ToSql<DbTimestamp, DB>,
+    {
+        fn to_sql<'b>(&'b self, out: &mut serialize::Output<'b, '_, DB>) -> serialize::Result {
+            <PrimitiveDateTime as ToSql<DbTimestamp, DB>>::to_sql(self, out)
+        }
+    }
+
+    #[cfg(feature = "diesel-pg")]
+    impl<DB> ToSql<DbTimestamptz, DB> for Timestamp
+    where
+        DB: Backend,
+        PrimitiveDateTime: ToSql<DbTimestamptz, DB>,
+    {
+        fn to_sql<'b>(&'b self, out: &mut serialize::Output<'b, '_, DB>) -> serialize::Result {
+            <PrimitiveDateTime as ToSql<DbTimestamptz, DB>>::to_sql(self, out)
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,7 +105,9 @@ pub use ts_str::{FormatString, TimestampStr};
 /// UTC Timestamp with nanosecond precision, millisecond-precision when serialized to serde (JSON).
 ///
 /// A `Deref`/`DerefMut` implementation is provided to gain access to the inner `PrimitiveDateTime` object.
-#[cfg_attr(feature = "diesel", derive(::diesel::FromSqlRow))]
+#[cfg_attr(feature = "diesel", derive(diesel::AsExpression, diesel::FromSqlRow))]
+#[cfg_attr(feature = "diesel", diesel(sql_type = diesel::sql_types::Timestamp))]
+#[cfg_attr(feature = "diesel-pg", diesel(sql_type = diesel::sql_types::Timestamptz))]
 #[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 #[repr(transparent)]
 pub struct Timestamp(PrimitiveDateTime);


### PR DESCRIPTION
Implement the traits needed to use `iso8601_timestamp` with Diesel for `TIMESTAMP` and `TIMESTAMPTZ` fields.

Gated behind the `diesel` and `diesel-pg` feature flags respectively