### PR TITLE
UniFFI compatibility feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ rusqlite = ["dep:rusqlite", "std"]
 rand = ["dep:rand", "time/rand"]
 quickcheck = ["dep:quickcheck", "time/quickcheck"]
 schema = ["schemars"]
+uniffi = ["uniffi_core"]
 nightly = []
 verify = []                                        # Verify numeric input during parsing
 lookup = []                                        # Use lookup table during formatting
@@ -45,6 +46,7 @@ worker = { optional = true, version = "0.0.18" }
 js-sys = { optional = true, version = "0.3" }
 ramhorns = { optional = true, version = "0.14" }
 rkyv = { optional = true, version = "0.7", default-features = false, features = ["validation"] }
+uniffi_core = { optional = true, version = "0.25", default-features = false }
 
 [dev-dependencies]
 time = { version = "0.3", features = ["macros", "parsing", "formatting"] }
@@ -54,6 +56,7 @@ iso8601 = "0.6"
 ciborium = "0.2"
 serde = { version = "1", features = ["derive"] }
 rkyv = { version = "0.7", default-features = true }
+uniffi = "0.25"
 
 [[bench]]
 name = "timestamp"

--- a/README.md
+++ b/README.md
@@ -83,3 +83,7 @@ Similarly, when deserializing, it supports either an ISO8601 string or an `i64` 
 
 * `ramhorns`
     - Implements `Content` for `Timestamp`, formatting it as a regular ISO8601 timestamp. Note that `ramhorns` is GPLv3.
+
+* `uniffi`
+    - Implements `uniffi_core::FfiConverter` and friends for `Timestamp`, allowing it to be used identically to `SystemTime`. This is more efficient than converting to `SystemTime` and then serializing.
+    - Note that uniffi has a bug that prevents the single second before the Unix Epoch from being represented. `Timestamp`'s implementation matches this.

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,2 +1,3 @@
-max_width = 110
+max_width = 115
 single_line_if_else_max_width = 100
+chain_width = 100


### PR DESCRIPTION
This matches the bug present in UniFFI, but is compatible with `SystemTime` for it. Enable the `uniffi` cargo feature to opt into the trait implementations.

@Sajjon would you like to test this branch for your application?