### PR TITLE
Convert time::Duration to std::time::Duration

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,6 +100,7 @@
 #![cfg_attr(feature = "nightly", feature(core_intrinsics))]
 #![warn(missing_docs)]
 
+use core::convert::TryInto;
 use core::ops::{AddAssign, Deref, DerefMut, SubAssign};
 
 #[cfg(feature = "std")]
@@ -163,7 +164,11 @@ impl From<SystemTime> for Timestamp {
 #[cfg(feature = "std")]
 impl From<Timestamp> for SystemTime {
     fn from(ts: Timestamp) -> Self {
-        SystemTime::UNIX_EPOCH + ts.duration_since(Timestamp::UNIX_EPOCH)
+        let duration = ts.duration_since(Timestamp::UNIX_EPOCH);
+        let std_duration: std::time::Duration = duration
+            .try_into()
+            .expect("To always be able to convert between time::Duration and std::time::Duration");
+        SystemTime::UNIX_EPOCH + std_duration
     }
 }
 


### PR DESCRIPTION
This seems to fix it, strange that `time` did not implement `From` but `TryFrom` since it seems we should always be able to convert between the both, e.g.

```rust
#[cfg(feature = "std")]
impl From<std::time::Duration> for Duration {
    fn from(value: std::time::Duration) -> Self {
        Self::new(value.as_secs(), value.as_nanos())
    }
}

#[cfg(feature = "std")]
impl From<Duration> for std::time::Duration {
    fn from(value: Duration) -> Self {
        Self::new(value.seconds, value.nanoseconds)
    }
}

```